### PR TITLE
Fixing variable linting so it can be run as gulp develop

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -24,12 +24,12 @@
       width: 100%;
 
       &::placeholder {
-        color: $warm-grey;
+        color: $color-mid-dark;
       }
 
       &[disabled] {
-        color: $warm-grey;
-        background-color: $transparent;
+        color: $color-mid-dark;
+        background-color: $color-transparent;
       }
     }
 
@@ -68,12 +68,12 @@
     width: 100%;
 
     &::placeholder {
-      color: $warm-grey;
+      color: $color-mid-dark;
     }
 
     &[disabled] {
-      color: $warm-grey;
-      background-color: $transparent;
+      color: $color-mid-dark;
+      background-color: $color-transparent;
     }
   }
 
@@ -106,9 +106,9 @@
     }
 
     &[disabled] {
-      color: $warm-grey;
+      color: $color-mid-dark;
       background-image: none;
-      background-color: $transparent;
+      background-color: $color-transparent;
     }
 
     // Removes firefox dotted outline focusing
@@ -156,7 +156,7 @@
         top: 3px;
         width: 11px;
         height: 11px;
-        border: 1px solid $mid-grey;
+        border: 1px solid $color-mid-light;
         background: $white;
         border-radius: 2px;
       }
@@ -219,7 +219,7 @@
         top: 1px;
         width: 13px;
         height: 13px;
-        border: 1px solid $mid-grey;
+        border: 1px solid $color-mid-light;
         background: $white;
         border-radius: 50%;
       }
@@ -343,7 +343,7 @@
       content: '';
       padding-right: 10px;
       background-color: $gallery-grey;
-      color: $warm-grey;
+      color: $color-mid-dark;
       text-align: right;
     }
   }

--- a/scss/_layout_row.scss
+++ b/scss/_layout_row.scss
@@ -9,8 +9,8 @@
 @mixin maas-row {
 
   .row {
-    background-color: $transparent;
-    border-top: 1px dotted $mid-grey;
+    background-color: $color-transparent;
+    border-top: 1px dotted $color-mid-light;
 
     &:first-of-type {
       border-top: 0;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -90,7 +90,7 @@
               font-weight: 400;
 
               .accordion__tab-link {
-                background: $transparent url('#{$asset-path}images/icons/cross.svg') top 7px right 0 no-repeat;
+                background: $color-transparent url('#{$asset-path}images/icons/cross.svg') top 7px right 0 no-repeat;
                 text-decoration: none;
               }
 
@@ -113,9 +113,9 @@
   %accordion__tab-title {
     padding: 12px 20px;
     margin: 0;
-    color: $warm-grey;
+    color: $color-mid-dark;
     cursor: pointer;
-    background: $transparent url('#{$asset-path}images/forms/chevron-down.svg') top 20px right 20px no-repeat;
+    background: $color-transparent url('#{$asset-path}images/forms/chevron-down.svg') top 20px right 20px no-repeat;
   }
   // scss-lint:enable NestingDepth SelectorDepth
 }

--- a/scss/_patterns_action-card.scss
+++ b/scss/_patterns_action-card.scss
@@ -23,7 +23,7 @@
     }
 
     .action-card__controls {
-      border-top: 1px dotted $warm-grey;
+      border-top: 1px dotted $color-mid-dark;
       width: 100%;
       display: inline-block;
       margin: 10px 0 0;

--- a/scss/_patterns_code.scss
+++ b/scss/_patterns_code.scss
@@ -11,7 +11,7 @@
     overflow: auto;
     margin: .5em 0;
     padding: 1em;
-    border: 1px solid $mid-grey;
+    border: 1px solid $color-mid-light;
     border-radius: .5em;
     background-color: $white;
     color: $cool-grey;

--- a/scss/_patterns_forms.scss
+++ b/scss/_patterns_forms.scss
@@ -39,7 +39,7 @@
       &.form__group--subtle {
 
         .form__group-label {
-          color: $warm-grey;
+          color: $color-mid-dark;
         }
 
         input,
@@ -49,14 +49,14 @@
           background-color: transparent;
 
           &:hover {
-            border-color: $mid-grey;
+            border-color: $color-mid-light;
             background-color: $white;
             outline: none;
           }
 
           &:active,
           &:focus {
-            border-color: $warm-grey;
+            border-color: $color-mid-dark;
             background-color: $white;
             outline: none;
           }
@@ -83,7 +83,7 @@
           input,
           select,
           textarea {
-            border-color: $mid-grey;
+            border-color: $color-mid-light;
             background-color: $white;
             outline: none;
           }
@@ -97,7 +97,7 @@
           input,
           select,
           textarea {
-            border-color: $mid-grey;
+            border-color: $color-mid-light;
             background-color: $white;
             outline: none;
           }
@@ -180,7 +180,7 @@
 
     .form__help-text {
       @include font-size(14px);
-      color: $warm-grey;
+      color: $color-mid-dark;
     }
   }
 

--- a/scss/_patterns_header.scss
+++ b/scss/_patterns_header.scss
@@ -11,7 +11,7 @@
   .banner {
     background-color: $black;
 
-    @media only screen and (min-width: $navigation-threshold) {
+    @media only screen and (min-width: $breakpoint-medium) {
       box-shadow: none;
 
       .nav-primary {
@@ -46,7 +46,7 @@
             }
 
             &.active {
-              background-color: $transparent;
+              background-color: $color-transparent;
               box-shadow: inset 0 -3px $link-hover;
 
               &:hover {

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -128,7 +128,7 @@
       }
 
       &-grey {
-        background: url('data:image/svg+xml;utf8, <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="success"><rect id="rect6708" x="0" y="9.99999989e-06" width="16" height="16"></rect><circle id="circle6710" stroke="#{$warm-grey}" stroke-width="1.5" fill="#{$warm-grey}" cx="8" cy="8.00001" r="7.2500086"></circle><polygon id="path6712" fill="#{$white}" points="11.80029 4.92345 11.73439 4.98115 6.99964 9.12837 4.22407 6.74743 3.38501 7.69631 7.00033 11.50002 12.5 5.71278 11.80029 4.92349"></polygon></g></g></svg>');
+        background: url('data:image/svg+xml;utf8, <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="success"><rect id="rect6708" x="0" y="9.99999989e-06" width="16" height="16"></rect><circle id="circle6710" stroke="#{$color-mid-dark}" stroke-width="1.5" fill="#{$color-mid-dark}" cx="8" cy="8.00001" r="7.2500086"></circle><polygon id="path6712" fill="#{$white}" points="11.80029 4.92345 11.73439 4.98115 6.99964 9.12837 4.22407 6.74743 3.38501 7.69631 7.00033 11.50002 12.5 5.71278 11.80029 4.92349"></polygon></g></g></svg>');
         background-size: 100% 100%;
       }
     }

--- a/scss/_patterns_page-header.scss
+++ b/scss/_patterns_page-header.scss
@@ -28,7 +28,7 @@
         padding: 8px 10px;
         width: auto;
         box-sizing: border-box;
-        border: 1px solid $transparent;
+        border: 1px solid $color-transparent;
         margin: -20px 0 -20px -10px;
         border-radius: 2px;
         color: $cool-grey;
@@ -82,7 +82,7 @@
       display: inline-block;
       position: relative;
       margin-left: 20px;
-      color: $warm-grey;
+      color: $color-mid-dark;
 
       .page-header__status-check {
         @include font-size(16px);
@@ -128,7 +128,7 @@
       }
 
       .page-header__section {
-        border-top: 1px dotted $warm-grey;
+        border-top: 1px dotted $color-mid-dark;
         padding-top: 20px;
         padding-bottom: 20px;
       }

--- a/scss/_patterns_search.scss
+++ b/scss/_patterns_search.scss
@@ -24,7 +24,7 @@
       appearance: textfield;
 
       &::placeholder {
-        color: $warm-grey;
+        color: $color-mid-dark;
       }
 
       // IE10+
@@ -57,7 +57,7 @@
       position: absolute;
       top: 15px;
       right: 15px;
-      background-color: $transparent;
+      background-color: $color-transparent;
       background-image: url('#{$asset-path}images/icons/magnifying_glass.svg');
       background-position: center;
       background-repeat: no-repeat;
@@ -72,7 +72,7 @@
       border: 0;
 
       &:hover {
-        background-color: $transparent;
+        background-color: $color-transparent;
         background-image: url('#{$asset-path}images/icons/magnifying_glass.svg');
       }
 

--- a/scss/_patterns_tables.scss
+++ b/scss/_patterns_tables.scss
@@ -7,7 +7,7 @@
 /// MAAS table styling
 /// @group maas table
 @mixin maas-table {
-  @include tables($alto-grey, $warm-grey, 16px, 13px);
+  @include tables($color-mid-light, $color-mid-dark, 16px, 13px);
   @include table-columns(100);
 }
 
@@ -440,7 +440,7 @@
     .table__input {
       display: inline-block;
       background-color: $white;
-      border-color: $alto-grey;
+      border-color: $color-mid-light;
       background-position: right 10px top 16px;
       margin: -7px 0;
 
@@ -501,7 +501,7 @@
           display: block;
           margin: 0 auto;
           width: calc(100% - 20px);
-          border-top: 1px dotted $alto-grey;
+          border-top: 1px dotted $color-mid-light;
           position: absolute;
           height: 1px;
           content: '';
@@ -533,7 +533,7 @@
             display: block;
             margin: 0 auto;
             width: calc(100% - 20px);
-            border-top: 1px dotted $alto-grey;
+            border-top: 1px dotted $color-mid-light;
             position: absolute;
             height: 1px;
             content: '';
@@ -546,7 +546,7 @@
 
           .table__input {
             background-color: $white;
-            border-color: $alto-grey;
+            border-color: $color-mid-light;
             background-position: right 10px top 16px;
             pointer-events: all;
 
@@ -586,7 +586,7 @@
 
   $states: (
     error: $error,
-    warning: $warning,
+    warning: $color-warning,
     success: $success,
     information: $information
   );

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -16,13 +16,13 @@
       list-style-type: none;
 
       .tabs__tab-link {
-        color: $warm-grey;
+        color: $color-mid-dark;
         text-decoration: none;
         border-bottom: 0;
       }
 
       &:hover .tabs__tab-link {
-        border-bottom: 3px solid $warm-grey;
+        border-bottom: 3px solid $color-mid-dark;
       }
 
       &:after {

--- a/scss/_settings_defaults.scss
+++ b/scss/_settings_defaults.scss
@@ -24,8 +24,8 @@ $line-height-ratio:     $base-line-height / $base-font-size;
 /// MAAS Text styles
 $text-color:            $cool-grey;
 $headline-color:        $cool-grey;
-$alt-headline-color:    $warm-grey;
-$link-color:            $brand-color;
+$alt-headline-color:    $color-mid-dark;
+$link-color:            $color-dark;
 $link-border:           #c2c2c2;
 $link-hover:            #dd4814;
 
@@ -63,9 +63,9 @@ $breakpoint-large:      $site-max-width;
 
 // MAAS form states
 $states: (
-  error: $error,
+  error: $color-negative,
   off: $outline,
-  warning: $warning,
+  warning: $color-warning,
   success: $success,
   on: $success,
   information: $information,

--- a/scss/_utilities_borders.scss
+++ b/scss/_utilities_borders.scss
@@ -6,7 +6,7 @@
 
 /// Borders
 /// @group Borders
-@mixin maas-borders($border-color: $mid-grey, $border-width: 1px) {
+@mixin maas-borders($border-color: $color-mid-light, $border-width: 1px) {
   .u-border {
     border: $border-width dotted $border-color !important;
 

--- a/scss/_utilities_state.scss
+++ b/scss/_utilities_state.scss
@@ -9,7 +9,7 @@
 @mixin maas-state {
 
   .u-text--subtle {
-    color: $warm-grey;
+    color: $color-mid-dark;
     font-size: .9375rem;
   }
 


### PR DESCRIPTION
#### What's this PR do?

This branch just sets up all the content files required for the docs theme. This also fixes a few variable linting issues so in future development `gulp develop` can be run.
#### Where should the reviewer start?

Pull the branch down and run `npm i`
#### How should this be manually tested?

Inspect all the files are there for the relative scss files and that gulp run tasks work.
#### Any background context you want to provide?

This won't currently work with vf.io as its tightly coupled with the vanilla framework theme and docs theme will require a bit more setup to work with it or will require its own repo set up just for this branch
