### PR TITLE
Applying new mobile styles to the secondary navigation

### DIFF
--- a/scss/_patterns.page-navigation.scss
+++ b/scss/_patterns.page-navigation.scss
@@ -25,7 +25,7 @@
       position: relative;
 
       &::before {
-        background: linear-gradient(90deg,hsla(0,0%,100%,0) 0,#fff);
+        background: linear-gradient(90deg, hsla(0, 0%, 100%, 0) 0,$white);
         box-sizing: border-box;
         content: '\203A';
         color: $warm-grey;

--- a/scss/_patterns.page-navigation.scss
+++ b/scss/_patterns.page-navigation.scss
@@ -13,7 +13,7 @@
     background: $white;
     box-shadow: 0 1px 1px rgba(0, 0, 0, .1);
     padding: 0 20px;
-    height: auto !important;
+    height: auto;
     width: 100% !important;
     float: left;
     overflow: visible;
@@ -52,6 +52,7 @@
       @media only screen and (max-width : $breakpoint-medium) {
         box-sizing: unset;
         padding-bottom: 20px;
+        overflow: scroll;
         position: relative;
         white-space: nowrap;
         width: 100%;

--- a/scss/_patterns.page-navigation.scss
+++ b/scss/_patterns.page-navigation.scss
@@ -22,6 +22,25 @@
 
     @media only screen and (max-width : $breakpoint-medium) {
       padding: 0;
+      position: relative;
+
+      &::before {
+        background: linear-gradient(90deg,hsla(0,0%,100%,0) 0,#fff);
+        box-sizing: border-box;
+        content: '\203A';
+        color: $warm-grey;
+        display: block;
+        font-size: 2rem;
+        height: 52px;
+        line-height: 52px;
+        padding: 0 15px;
+        position: absolute;
+        right: 0;
+        text-align: right;
+        top: 1px;
+        width: 100px;
+        z-index: 10;
+      }
     }
 
     &__links {
@@ -29,6 +48,10 @@
       width: auto;
 
       @media only screen and (max-width : $breakpoint-medium) {
+        height: 54px;
+        overflow: scroll;
+        position: relative;
+        white-space: nowrap;
         width: 100%;
       }
     }
@@ -46,11 +69,10 @@
       border-radius: 0;
 
       @media only screen and (max-width : $breakpoint-medium) {
-        width: 100%;
-
-        + .page-navigation__link {
-          border-top: 1px dotted $outline;
-        }
+        display: inline-block;
+        float: none;
+        width: auto;
+        z-index: 1;
       }
 
       &:hover {

--- a/scss/_patterns.page-navigation.scss
+++ b/scss/_patterns.page-navigation.scss
@@ -23,6 +23,8 @@
     @media only screen and (max-width : $breakpoint-medium) {
       padding: 0;
       position: relative;
+      height: 54px;
+      overflow: hidden;
 
       &::before {
         background: linear-gradient(90deg, hsla(0, 0%, 100%, 0) 0,$white);
@@ -48,8 +50,8 @@
       width: auto;
 
       @media only screen and (max-width : $breakpoint-medium) {
-        height: 54px;
-        overflow: scroll;
+        box-sizing: unset;
+        padding-bottom: 20px;
         position: relative;
         white-space: nowrap;
         width: 100%;


### PR DESCRIPTION
#### What's this PR do?

Applies the new secondary navigation design which can be found here https://github.com/CanonicalLtd/MAAS-design/blob/master/Mobile%20navigation/Flat_Visuals/Mobile-secondary-nav.png


#### Where should the reviewer start?

- Pull down the branch and run ```npm i``` and then ```gulp build```

#### How should this be manually tested?

- Open ```demo/index.html``` and test the secondary navigation in mobile view. The content should overflow scroll at ```768px``` breakpoint.