### PR TITLE
Styles external links as external (fixing #66)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -38,12 +38,12 @@
                             <li><a href="index.html" class="active">Documentation</a></li>
                             <li><a href="demo-listing.html">Demo listing page</a></li>
                             <li><a href="demo-details.html">Demo details page</a></li>
-                            <li><a href="https://github.com/ubuntudesign/maas-gui-vanilla-theme">MAAS GUI GitHub Project</a></li>
+                            <li><a class="p-link--external" href="https://github.com/ubuntudesign/maas-gui-vanilla-theme">MAAS GUI GitHub Project</a></li>
                         </ul>
                         <div class="nav-secondary">
                             <ul>
-                                <li><a href="http://maas.io">MAAS Website</a></li>
-                                <li><a href="https://github.com/ubuntudesign/vanilla-framework">Vanilla Framework</a></li>
+                                <li><a class="p-link--external" href="http://maas.io">MAAS Website</a></li>
+                                <li><a class="p-link--external" href="https://github.com/ubuntudesign/vanilla-framework">Vanilla Framework</a></li>
                             </ul>
                         </div>
                     </div>
@@ -73,7 +73,7 @@
                     <div class="wrapper--inner">
                         <div class="eight-col">
                             <h1>Introduction</h1>
-                            <p>The MAAS GUI Framework is a HTML, CSS framework developed for <a href="http://maas.io/">MAAS</a> a cloud application built by <a href="http://www.canonical.com">Canonical</a> the Ubuntu people. The framework is written in <a href="http://sass-lang.com/">Sass</a> and is a theme based off our own <a href="https://github.com/ubuntudesign/vanilla-framework">Vanilla framework</a>. We created this framework to act as the central location for all our MAAS web UI components, styles and patterns.</p>
+                            <p>The MAAS GUI Framework is a HTML, CSS framework developed for <a class="p-link--external" href="http://maas.io/">MAAS</a> a cloud application built by <a class="p-link--external" href="http://www.canonical.com">Canonical</a> the Ubuntu people. The framework is written in <a class="p-link--external" href="http://sass-lang.com/">Sass</a> and is a theme based off our own <a class="p-link--external" href="https://github.com/ubuntudesign/vanilla-framework">Vanilla framework</a>. We created this framework to act as the central location for all our MAAS web UI components, styles and patterns.</p>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
#### What's this PR do?

Adds external-link classes to the links “MAAS GUI GitHub Project”, “MAAS Website”, “Vanilla Framework” etc.

#### Where should the reviewer start?

Don’t know (`npm i` errors out for me)

#### How should this be manually tested?

Open the demo page

#### What are the relevant tickets?

#66 